### PR TITLE
option handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,5 @@
         "psr-4": {
             "WyriHaximus\\React\\Tests\\Guzzle\\HttpClient\\": "tests/"
         }
-    },
-    "extra": {
-    	"branch-alias": {
-    		"dev-option-handling": "3.0.x-dev"
-    	}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
         "psr-4": {
             "WyriHaximus\\React\\Tests\\Guzzle\\HttpClient\\": "tests/"
         }
+    },
+    "extra": {
+    	"branch-alias": {
+    		"dev-option-handling": "3.0.x-dev"
+    	}
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -118,7 +118,7 @@ class Request
         ProgressInterface $progress = null
     ) {
         $this->request = $request;
-        $this->options = array_replace_recursive($this->defaultOptions, $options);
+        $this->applyOptions($options);
         $this->httpClient = $httpClient;
         $this->loop = $loop;
 
@@ -395,5 +395,9 @@ class Request
             'request' => $request,
             'loop' => $this->loop,
         ]);
+    }
+    
+    private function applyOptions(array $options = []) {
+        $this->options = array_replace_recursive($this->defaultOptions, $options);
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -114,22 +114,12 @@ class Request
         RequestInterface $request,
         array $options,
         ReactHttpClient $httpClient,
-        LoopInterface $loop,
-        ProgressInterface $progress = null
+        LoopInterface $loop
     ) {
         $this->request = $request;
         $this->applyOptions($options);
         $this->httpClient = $httpClient;
         $this->loop = $loop;
-
-        if ($progress instanceof ProgressInterface) {
-            $this->progress = $progress;
-        } elseif (isset($this->options['client']['progress']) && is_callable($this->options['client']['progress'])) {
-            $this->progress = new Progress($this->options['client']['progress']);
-        } else {
-            $this->progress = new Progress(function () {
-            });
-        }
     }
 
     /**
@@ -146,11 +136,10 @@ class Request
         array $options,
         ReactHttpClient $httpClient,
         LoopInterface $loop,
-        ProgressInterface $progress = null,
         Request $requestObject = null
     ) {
         if ($requestObject === null) {
-            $requestObject = new static($request, $options, $httpClient, $loop, $progress);
+            $requestObject = new static($request, $options, $httpClient, $loop);
         }
         return $requestObject->perform();
     }
@@ -399,5 +388,12 @@ class Request
     
     private function applyOptions(array $options = []) {
         $this->options = array_replace_recursive($this->defaultOptions, $options);
+        
+        if (isset($this->options['client']['progress']) && is_callable($this->options['client']['progress'])) {
+            $this->progress = new Progress($this->options['client']['progress']);
+        } else {
+            $this->progress = new Progress(function () {
+            });
+        }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -104,9 +104,10 @@ class Request
 
     /**
      * @param RequestInterface $request
+     * @param array $options
      * @param ReactHttpClient $httpClient
      * @param LoopInterface $loop
-     * @param ProgressInterface $progress
+
      */
     protected function __construct(
         RequestInterface $request,
@@ -125,8 +126,6 @@ class Request
      * @param array $options
      * @param ReactHttpClient $httpClient
      * @param LoopInterface $loop
-     * @param ProgressInterface $progress
-     * @param Request $requestObject
      * @return \React\Promise\Promise
      */
     public static function send(

--- a/src/Request.php
+++ b/src/Request.php
@@ -384,7 +384,8 @@ class Request
         ]);
     }
     
-    private function applyOptions(array $options = []) {
+    private function applyOptions(array $options = [])
+    {
         $this->options = array_replace_recursive($this->defaultOptions, $options);
         
         // provides backwards compatibility for Guzzle 3-5.

--- a/src/Request.php
+++ b/src/Request.php
@@ -271,9 +271,8 @@ class Request
     protected function onResponse(HttpResponse $response, HttpRequest $request)
     {
         $this->httpResponse = $response;
-        if (!empty($this->options['sink'])) {
+        if (isset($this->options['sink'])) {
             $this->saveTo();
-            return;
         }
 
         $this->handleResponse($request);

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -21,6 +21,14 @@ use React\HttpClient\Client as HttpClient;
  */
 class RequestFactory
 {
+    /**
+     * 
+     * @param RequestInterface $request
+     * @param array $options
+     * @param HttpClient $httpClient
+     * @param LoopInterface $loop
+     * @return \React\Promise\Promise
+     */
     public function create(RequestInterface $request, array $options, HttpClient $httpClient, LoopInterface $loop)
     {
         return Request::send($request, $options, $httpClient, $loop);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -33,6 +33,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             ],
             'body' => 'foo:bar',
         ];
+        
+        $options = [];
 
         $loop = Phake::mock('React\EventLoop\LoopInterface');
 
@@ -60,7 +62,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = Phake::partialMock(
             'WyriHaximus\React\Guzzle\HttpClient\Request',
             $psrRequest,
-            $requestArray,
+            $options,
             $client,
             $loop
         );
@@ -70,7 +72,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $request->send(
             $psrRequest,
-            $requestArray,
+            $options,
             $client,
             $loop,
             $request

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -73,7 +73,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             $requestArray,
             $client,
             $loop,
-            null,
             $request
         ));
 


### PR DESCRIPTION
Fix bug #4.
Fix bug #3 .
Fix bug [wyrihaximus/react-guzzle-psr7 - 8](https://github.com/WyriHaximus/react-guzzle-psr7/issues/8)
Reference [WyriHaximus/react-guzzle-psr7 - 3](https://github.com/WyriHaximus/react-guzzle-psr7/issues/3) - streams not handled properly when using Guzzle 6

Moved option handling from `Request::__construct()` to `Request::applyOptions()`.
Modified default options array to be Guzzle6 compliant.
Provided shim to forward convert Guzzle 4-5 option array to Guzzle 6.

Removed `ProgressInterface` from `Request::__construct()`, `Request::send()` method signatures.  External packages only access `RequestFactory::create()` which does not provide an instance of `ProgressInterface`.  This ability still exists through the use of the 'progress' option.

Explicitly state options within tests.