### PR TITLE
fix 'delay' option for guzzle 6

### DIFF
--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -164,6 +164,10 @@ class RequestFactory
             unset($options['save_to']);
         }
 
+        if (isset($options['delay'])) {
+            $options['delay'] = $options['delay']/1000;
+        }
+        
         if (isset($options['allow_redirects'])) {
             $this->convertRedirectOption($options);
         }


### PR DESCRIPTION
In Guzzle 6.x, the 'delay' option is the number of milliseconds.

but the func 'timedPromise' requires interval(second) arg in seconds (int | float)

https://github.com/WyriHaximus/react-guzzle-http-client/blob/c4b6c03396e6311f4765543a351d285ebd4611c7/src/RequestFactory.php#L51-L55